### PR TITLE
Miscellaneous updates

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - hvplot
     - jinja2
     - neuclease >=0.7.3
-    - neuprint-python
+    - neuprint-python >=0.5.1
     - pyarrow
     - requests
     - ujson

--- a/flyem_snapshot/bin/update_neuprint_annotations.py
+++ b/flyem_snapshot/bin/update_neuprint_annotations.py
@@ -271,14 +271,14 @@ def _compute_changemask(clio_df, neuprint_df):
 
     # Find the positions with different values.
     # If both are NaN/None, they're considered equal.
-    changemask = (neuprint_df != clio_df) & (~neuprint_df.isnull() | ~clio_df.isnull())
+    changemask = (neuprint_df != clio_df) & (neuprint_df.notnull() | clio_df.notnull())
 
     # This will ensure that all-float columns have float dtype.
     clio_df = clio_df.infer_objects(copy=False)
     neuprint_df = neuprint_df.infer_objects(copy=False)
 
     # Special handling for float columns: We don't demand exact equality.
-    float_cols = (clio_df.dtypes == float) & (neuprint_df.dtypes == float)
+    float_cols = (clio_df.dtypes == float) & (neuprint_df.dtypes == float)  # noqa: E721
     changemask.loc[:, float_cols] &= ~np.isclose(
         clio_df.loc[:, float_cols],
         neuprint_df.loc[:, float_cols]

--- a/flyem_snapshot/bin/update_neuprint_annotations.py
+++ b/flyem_snapshot/bin/update_neuprint_annotations.py
@@ -21,6 +21,8 @@ import traceback
 import argparse
 from collections import namedtuple
 
+from requests import HTTPError
+
 logger = logging.getLogger(__name__)
 DvidDetails = namedtuple('DvidInstance', 'server uuid instance')
 
@@ -33,7 +35,16 @@ def main():
     parser.add_argument(
         '--output-directory', '-o',
         help="Optional. Export summary files to an output directory. "
-             "If the directory already contains summary files from a prior run, they'll be overwritten.")
+             "If the directory already contains summary files from a prior run, they'll be overwritten."
+    )
+    parser.add_argument(
+        '--default-transaction-size', '-b',
+        type=int,
+        default=200,
+        help="Neuron properties will be updated in batches. "
+             "This is the batch size of each transaction, unless some transactions fail due to timeout errors, "
+             "in which case they will be retried in smaller batches."
+    )
     parser.add_argument(
         '--dry-run', action='store_true',
         help="If given, generate the output files (including cypher commands) for the update, but don't "
@@ -62,7 +73,7 @@ def main():
     )
 
     try:
-        update_neuprint_annotations(dvid_details, args.dry_run, args.output_directory, neuprint_client)
+        update_neuprint_annotations(dvid_details, args.dry_run, args.output_directory, args.default_transaction_size, neuprint_client)
     except BaseException:
         if d := args.output_directory:
             os.makedirs(d, exist_ok=True)
@@ -73,7 +84,7 @@ def main():
     logger.info("DONE")
 
 
-def update_neuprint_annotations(dvid_details, dry_run=False, log_dir=None, client=None):
+def update_neuprint_annotations(dvid_details, dry_run=False, log_dir=None, default_transaction_size=100, client=None):
     """
     Compare neuronjson annotations from DVID/Clio with the Neuron/Segment
     properties from Neuprint, and update the Neuprint properties to match
@@ -85,6 +96,16 @@ def update_neuprint_annotations(dvid_details, dry_run=False, log_dir=None, clien
     Args:
         dvid_details:
             tuple (server, uuid, instance)
+        dry_run:
+            If True, generate the output files (including cypher commands) for the update,
+            but don't actually execute the transactions to update neuprint.
+        log_dir:
+            Optional.  If given, write summary files to this directory.
+        default_transaction_size:
+            The default batch size for each transaction.
+            If any transaction fails due to a timeout error,
+            then it and all subsequent transactions will be retried
+            using smaller transactions.
         client:
             neuprint Client
             Requires admin access to the neuprint server.
@@ -106,7 +127,7 @@ def update_neuprint_annotations(dvid_details, dry_run=False, log_dir=None, clien
     _dump_summary_files(clio_df, neuprint_df, changemask, commands, log_dir)
 
     clio_df, neuprint_df, changemask, commands = _apply_neuprint_annotation_updates(
-        clio_df, neuprint_df, changemask, commands, timestamp, dry_run, client)
+        clio_df, neuprint_df, changemask, commands, timestamp, dry_run, default_transaction_size, client)
 
     return clio_df, neuprint_df, changemask, commands
 
@@ -122,9 +143,10 @@ def _dump_summary_files(clio_df, neuprint_df, changemask, commands, log_dir):
     changemask.to_csv(f'{d}/changemask.csv', header=True, index=True)
     with open(f'{d}/cypher-update-commands.cypher', 'w') as f:
         f.write('\n'.join(commands))
+        f.write('\n')
 
 
-def _apply_neuprint_annotation_updates(clio_df, neuprint_df, changemask, commands, timestamp, dry_run, client):
+def _apply_neuprint_annotation_updates(clio_df, neuprint_df, changemask, commands, timestamp, dry_run, default_transaction_size, client):
     from neuclease.util import Timer
     _update_meta_neuron_properties(clio_df, dry_run, client)
 
@@ -136,7 +158,7 @@ def _apply_neuprint_annotation_updates(clio_df, neuprint_df, changemask, command
     else:
         msg = f"Updating {len(changemask)} Segments with {changemask.sum().sum()} out-of-date properties."
         with Timer(msg, logger):
-            _post_commands(commands, client)
+            _post_commands(commands, default_transaction_size, client)
         _update_meta_timestamp(timestamp, client)
 
     # Restrict summary DataFrames to the minimal subset
@@ -371,22 +393,49 @@ def _generate_commands(clio_df, changemask, clio_segments):
     return commands
 
 
-def _post_commands(commands, client):
+def _post_commands(commands, batch_size, client):
     """
     Send the list of cypher commands to the neuprint
-    server using a Transaction for each one.
+    server using a series of Transactions.
+
+    At first, each transaction will include a batch of commands (of the given size),
+    but if one transaction fails, the batch size is halved and the commands are re-sent
+    with the new batch size.  This continues until the batch size is 1.
+    If any transaction still fails using batch size 1, we give up and raise an exception.
     """
-    from neuclease.util import tqdm_proxy, tqdm_proxy_config
+    from itertools import chain
+    from neuclease.util import tqdm_proxy, tqdm_proxy_config, iter_batches
     from neuprint.admin import Transaction
 
     # I want logged progress bars, no matter what.
     tqdm_proxy_config['output_file'] = 'logger'
 
-    # Send each command in its own transaction to avoid
-    # timeouts that occur with large transactions.
-    for q in tqdm_proxy(commands):
-        with Transaction(client.dataset, client=client) as t:
-            t.query(q)
+    with tqdm_proxy(total=len(commands)) as progress:
+        while True:
+            try:
+                batch_size = min(batch_size, len(commands))
+                batches = iter_batches(commands, batch_size)
+                batch_iter = iter(batches)
+
+                for batch in batch_iter:
+                    with Transaction(client.dataset, client=client) as t:
+                        for command in batch:
+                            t.query(command)
+                    progress.update(len(batch))
+
+                # Done: All (remaining) batches succeeded without error.
+                break
+            except HTTPError:
+                if batch_size == 1:
+                    logger.error("Transaction failed even with batch size 1.  Giving up.")
+                    logger.error("Failed cypher command was:")
+                    logger.error(batch[0])
+                    raise
+                logger.warning(f"Transaction failed with batch size: {batch_size}")
+                logger.warning("Moving the failed commands to the end of the queue.")
+                logger.warning(f"Resuming with smaller batch size: {batch_size // 2}")
+                commands = [*chain(*batch_iter), *batch]
+                batch_size //= 2
 
 
 POINT_PATTERN = re.compile(r'{x:\d+, y:\d+, z:\d+}')
@@ -409,5 +458,6 @@ def _cypher_literal(x):
 if __name__ == "__main__":
     # sys.argv.extend(['-o', '/tmp/debug'])
     # sys.argv.extend(['--dry-run'])
+    # sys.argv.extend(['--default-transaction-size', '200'])
     # sys.argv.extend("emdata6.int.janelia.org:9000 :master segmentation_annotations neuprint-cns.janelia.org cns".split())
     main()

--- a/flyem_snapshot/caches.py
+++ b/flyem_snapshot/caches.py
@@ -49,6 +49,11 @@ def cached(serializer, cache_dir='cache'):
 class SerializerBase:
 
     def __init__(self, name, enforce_matching_signature=True):
+        """
+        If enforce_matching_signature is True, then the @cached decorator will assert
+        that the signature of the serializer's get_cache_key() method matches the
+        signature of the function it decorates.
+        """
         self.name = name
         self.enforce_matching_signature = enforce_matching_signature
 

--- a/flyem_snapshot/inputs/dvidseg.py
+++ b/flyem_snapshot/inputs/dvidseg.py
@@ -38,10 +38,14 @@ DvidSegSchema = {
 
 def load_dvidseg(cfg, snapshot_tag):
     """
-    Use the DVID config values to construct a PointLabeler object,
-    which can then be used to extract body IDs from arbitrary
-    coordinates in a DVID segmentation. (For example, to determine
-    the body IDs under synapse locations.)
+    This function doesn't actually read segmentation voxels.
+    It initializes a PointLabeler object, which can then be used
+    to extract body IDs from arbitrary coordinates in a DVID segmentation
+    (as specified via the uuid/instance in the config).
+
+    The main purpose of the PointLabeler is to determine the body IDs
+    under synapse locations or other point annotations (such as soma
+    locations, etc.).
     """
     if not cfg['server']:
         return None

--- a/flyem_snapshot/inputs/elements.py
+++ b/flyem_snapshot/inputs/elements.py
@@ -118,7 +118,11 @@ def _load_element_points(name, table_cfg):
         raise RuntimeError(f"Element table '{name}' doesn't have xyz and/or type columns.")
 
     if 'point_id' in element_df:
-        element_df = element_df.set_index('point_id')
+        element_df = (
+            element_df
+            .astype({'point_id': np.uint64})
+            .set_index('point_id')
+        )
     else:
         point_ids = encode_coords_to_uint64(element_df[[*'zyx']].values)
         element_df.index = pd.Index(point_ids, name='point_id')

--- a/flyem_snapshot/inputs/neurotransmitters.py
+++ b/flyem_snapshot/inputs/neurotransmitters.py
@@ -320,7 +320,9 @@ def _load_tbar_neurotransmitters(path, rescale, translations, synpoint_df):
     tbar_df = tbar_df.rename(columns=renames)
     nt_cols = list(renames.values())
 
-    if 'point_id' not in tbar_df.columns:
+    if 'point_id' in tbar_df.columns:
+        tbar_df['point_id'] = tbar_df['point_id'].astype(np.uint64)
+    else:
         tbar_df['point_id'] = encode_coords_to_uint64(tbar_df[[*'zyx']].values)
 
     tbar_df = tbar_df.set_index('point_id')
@@ -331,6 +333,11 @@ def _load_tbar_neurotransmitters(path, rescale, translations, synpoint_df):
     #   If there are synapses in synpoint_df which are not present in the tbar
     #   predictions, they will have NaN predictions after this merge.
     presyn_df = synpoint_df.query('kind == "PreSyn"')
+
+    # The merge below will silently produce incorrect results if one index is signed and the other is unsigned.
+    # In that case, pandas must be converting to float64 and losing precision.
+    assert tbar_df.index.name == presyn_df.index.name == 'point_id'
+    assert tbar_df.index.dtype == presyn_df.index.dtype == np.uint64
     tbar_df = presyn_df[['body', *'xyz']].merge(tbar_df.drop(columns=[*'xyz']), 'left', on='point_id')
     return tbar_df
 

--- a/flyem_snapshot/inputs/neurotransmitters.py
+++ b/flyem_snapshot/inputs/neurotransmitters.py
@@ -289,7 +289,7 @@ def _load_tbar_neurotransmitters(path, rescale, translations, synpoint_df):
     Drop predictions which fall outside of the known synapse set
     (as listed in synpoint_df).
     """
-    tbar_df = feather.read_feather(path).astype({'body': np.int64})
+    tbar_df = feather.read_feather(path)
     if tbar_df.index.name:
         tbar_df = tbar_df.reset_index()
 

--- a/flyem_snapshot/inputs/synapses.py
+++ b/flyem_snapshot/inputs/synapses.py
@@ -74,7 +74,6 @@ SnapshotSynapsesSchema = {
             # NO DEFAULT
         },
         "zone": {
-            # TODO: Eliminate the 'zone' feature in favor of more flexibility in defining report ROIs.
             "description":
                 "Specifically for the male CNS. Whether to PRE-FILTER the synapses to include the brain only, vnc only, or whole cns",
             "type": "string",
@@ -158,7 +157,7 @@ class RawSynapseSerializer(SynapseSerializerBase):
 
 
 @cached(RawSynapseSerializer('labeled-synapses'))
-def load_synapses(cfg, snapshot_tag, pointlabeler):
+def load_synapses(cfg, snapshot_tag, pointlabeler):  # noqa
     point_df, partner_df = _load_raw_synapses(cfg)
 
     point_df, partner_df = _filter_for_zone(point_df, partner_df, cfg['zone'])

--- a/flyem_snapshot/inputs/synapses.py
+++ b/flyem_snapshot/inputs/synapses.py
@@ -177,6 +177,11 @@ def _load_raw_synapses(cfg):
         point_df = feather.read_feather(points_path)
         partner_df = feather.read_feather(partners_path)
 
+    # Temporarily ensure point_id is in the columns to simplify the logic below.
+    # (We'll move it to the index below.)
+    if 'point_id' not in point_df.columns and point_df.index.name == 'point_id':
+        point_df = point_df.reset_index()
+
     if 'point_id' not in point_df.columns and not {*'zyx'} <= {*point_df.columns}:
         raise RuntimeError("Synapse point table doesn't have coordinates or point_id")
 

--- a/flyem_snapshot/inputs/synapses.py
+++ b/flyem_snapshot/inputs/synapses.py
@@ -174,12 +174,14 @@ def _load_raw_synapses(cfg):
 
     with Timer("Loading synapses from disk", logger):
         point_df = feather.read_feather(points_path)
-        partner_df = feather.read_feather(partners_path)
+        partner_df = feather.read_feather(partners_path).astype({'pre_id': np.uint64, 'post_id': np.uint64})
 
     # Temporarily ensure point_id is in the columns to simplify the logic below.
     # (We'll move it to the index below.)
     if 'point_id' not in point_df.columns and point_df.index.name == 'point_id':
         point_df = point_df.reset_index()
+
+    point_df = point_df.astype({'point_id': np.uint64})
 
     if 'point_id' not in point_df.columns and not {*'zyx'} <= {*point_df.columns}:
         raise RuntimeError("Synapse point table doesn't have coordinates or point_id")

--- a/flyem_snapshot/outputs/neuprint/annotations.py
+++ b/flyem_snapshot/outputs/neuprint/annotations.py
@@ -5,6 +5,9 @@ into the format neuprint needs (column names, status values, etc.)
 import re
 import logging
 
+import numpy as np
+import pandas as pd
+
 from neuclease.util import snakecase_to_camelcase
 
 logger = logging.getLogger(__name__)
@@ -146,11 +149,11 @@ def neuprint_segment_annotations(cfg, ann):
     logger.info(f"Annotation columns after renaming: {ann.columns.tolist()}")
 
     # Drop categorical dtype for this column before using replace()
-    ann['statusLabel'] = ann['statusLabel'].astype(str)
+    ann['statusLabel'] = ann['statusLabel'].astype('string')
 
     # Erase any values which are just "".
     # Better to leave them null.
-    ann = ann.replace('', None)
+    ann = ann.replace(["", pd.NA], [None, None])
 
     # If any columns are completely empty, remove them.
     allnull = ann.isnull().all(axis=0)

--- a/flyem_snapshot/outputs/neuprint/element.py
+++ b/flyem_snapshot/outputs/neuprint/element.py
@@ -91,7 +91,7 @@ def _export_neuprint_elements(cfg, point_df, roisets, *, config_name):
 
 def export_element_group_csv(subdir, roi_syn_props, i, group_rois, df):
     """
-    Element a single CSV file of Element nodes, in which the ROI for all
+    Export a single CSV file of Element nodes, in which the ROI for all
     points in the group are homogenous (i.e. all ROI columns are the same
     in every row).
 

--- a/flyem_snapshot/outputs/neuprint/neuroglancer.py
+++ b/flyem_snapshot/outputs/neuprint/neuroglancer.py
@@ -64,7 +64,7 @@ def export_neuroglancer_json_state(cfg, last_mutation):
 
     # First, write out a temporary version of the file before attempting to load as JSON.
     # If we fail to load the JSON for some reason, we can debug the temp file.
-    output_name = f'neuprint/{dset_tag}-ngstate.json'
+    output_name = f'neuprint/{dset_tag}.json'
     with open(output_name, 'w') as f:
         f.write(state_text)
 


### PR DESCRIPTION
This PR contains a few different updates.  Ideally I would split them into separate PRs, but since I'm not really asking for a formal review, I'm not going to take the time to do that.

Main points here:

- The synapse input tables were not being handled correctly in a few ways:
    - confidence filtering did not properly filter points and partners in a mutually consistent manner.
    - newer versions of Apache feather might actually populate the dataframe index, so I now allow the `point_id` to be present in either the columns or the index.
    - It is critical that `point_id` always be `uint64`, never `int64`.  If we mix those types, merges between two tables don't work properly.

- The `update_neuprint_annotations` script has been improved:
   -  It now groups update commands into larger batches, but falls back to smaller batches if timeouts occur.
   - I fixed an issue that cause unnecessary updates to the `status` property (it was due to confusion between `null` and `""`.

- The neuroglancer JSON state file which we export for neuprint to use didn't have the correct file name.  Now it does.

---

cc @StephanPreibisch
