### PR TITLE
neurotransmitter processing updates

### DIFF
--- a/flyem_snapshot/inputs/neurotransmitters.py
+++ b/flyem_snapshot/inputs/neurotransmitters.py
@@ -160,7 +160,8 @@ NeurotransmittersSchema = {
                 "Optional. Table of high-confidence experimental groundtruth, used to override type-level\n"
                 "predictions in the 'consensus' preduction column.\n"
                 "The expected columns match the columns in our final output (but we also accept their camelCase equivalents).\n"
-                "type, consensusNt, ntReference, otherNt, otherNtReference\n",
+                "type, consensusNt, ntReference, otherNt, otherNtReference\n"
+                "We also accept the same column names used in the groud-truth table: cell_type,ground_truth",
             "type": "string",
             "default": ""
         },
@@ -679,7 +680,7 @@ def _set_body_exp_gt_based_columns(cfg, body_df):
 
     # Overwrite cases where experimental groundtruth is available.
     exp_df = pd.read_csv(path)
-    exp_df = exp_df.rename(columns={'type': 'cell_type'})
+    exp_df = exp_df.rename(columns={'type': 'cell_type', 'ground_truth': 'consensus_nt'})
     exp_df = exp_df.rename(columns={c: camelcase_to_snakecase(c) for c in exp_df.columns})
     exp_df = exp_df.set_index('cell_type')
 

--- a/flyem_snapshot/inputs/neurotransmitters.py
+++ b/flyem_snapshot/inputs/neurotransmitters.py
@@ -371,6 +371,8 @@ def _compute_body_neurotransmitters(cfg, tbar_df, ann):
         if 'split' not in tbar_df:
             msg = "Can't make use of your ground-truth because your point data does not contain a 'split' column."
             raise RuntimeError(msg)
+        if gt_df['cell_type'].isnull().any() or gt_df['ground_truth'].isnull().any():
+            raise RuntimeError("Neurotransmitter ground-truth table contains null values.")
 
     # Append 'cell_type' column to point table
     tbar_df = tbar_df.merge(ann['type'].rename('cell_type'), 'left', on='body')

--- a/flyem_snapshot/inputs/neurotransmitters.py
+++ b/flyem_snapshot/inputs/neurotransmitters.py
@@ -552,6 +552,9 @@ def _calc_group_predictions(pred_df, ann, confusion_df, gt_df, groupcol):
     )
     df = group_pred.to_frame()
 
+    # Cells with no type at all should not be given an aggregate celltype prediction.
+    df.loc[df.index.isnull(), 'group_pred'] = None
+
     # Ensure that our final results will include all bodies (or types)
     # from the annotations, even if they weren't present in pred_df
     ann_types = ann['type'].rename('cell_type')


### PR DESCRIPTION
These changes implemented a few days ago to support loading our MaleCNS neurotransmitter predictions properly.  Aside from some minor updates related to null-value handling and CSV columns, the most important change is that the definition of the "training set" in the groundtruth data is now configurable.

(For the MaleCNS NT predictions, there was not (much) held out data that wasn't used in the `validation` set, so we simply compute our confusion matrix on the `validation` set.)

cc @StephanPreibisch
