### PR TITLE
Improvements to ROI hierarchy config handling

### DIFF
--- a/flyem_snapshot/main.py
+++ b/flyem_snapshot/main.py
@@ -552,6 +552,20 @@ def standardize_config(cfg, config_dir):
     # but we insert its loaded contents into the main config for all neuprint steps to use.
     if neuprintcfg['export-neuprint-snapshot'] and isinstance(neuprintcfg['meta'], str):
         metacfg = load_config(neuprintcfg['meta'], NeuprintMetaSchema)
+        with switch_cwd(os.path.dirname(neuprintcfg['meta'])):
+            def fix_hierarchy_paths(rh):
+                if isinstance(rh, str) and rh.endswith(('.json', '.yaml')):
+                    # Right now we don't tackle the case where a part of the hierarchy
+                    # included via a file and that file itself includes others files
+                    # which are not absolute paths.
+                    return os.path.abspath(rh)
+                elif isinstance(rh, dict):
+                    return {k: fix_hierarchy_paths(v) for k,v in rh.items()}
+                else:
+                    return rh
+
+            metacfg['roiHierarchy'] = fix_hierarchy_paths(metacfg['roiHierarchy'])
+
         neuprintcfg['meta'] = metacfg
 
 

--- a/flyem_snapshot/outputs/neuprint/meta.py
+++ b/flyem_snapshot/outputs/neuprint/meta.py
@@ -118,6 +118,20 @@ RoiHierarchySchema = {
     }
 }
 
+# This schema is used when the ROI hierarchy (or part of it)
+# is defined in a stand-alone file.  This is the schema of such a file.
+# (We have to define a special schema so that the 'definitions' of the
+# schema can be placed at the top level of the schema.)
+RoiHierarchyFileSchema = {
+    "default": {},
+    "definitions": {
+        "rh-def-recursive": RoiHierarchyDefinition
+    },
+    "additionalProperties": {
+        "$ref": "#/definitions/rh-def-recursive"
+    }
+}
+
 NeuronColumnSchema = {
     "type": "object",
     "default": {},
@@ -427,7 +441,7 @@ def load_roi_hierarchy(rhcfg, roisets):
             rois = roisets[roiset_name].keys()
             return {k: None for k in rois}
         elif re.match('.*(yaml|json)$', rhcfg):
-            rhcfg = load_config(rhcfg, RoiHierarchySchema)
+            rhcfg = load_config(rhcfg, RoiHierarchyFileSchema)
             return load_roi_hierarchy(rhcfg, roisets)
         raise RuntimeError(f"bad string entry in roi-hierarchy: '{rhcfg}'")
 

--- a/flyem_snapshot/outputs/reports.py
+++ b/flyem_snapshot/outputs/reports.py
@@ -501,6 +501,16 @@ def _get_neuroglancer_base_link(state_path):
 
 @PrefixFilter.with_context("downstream capture")
 def _export_downstream_capture_histogram(cfg, snapshot_tag, roiset, name, partner_df):
+    if not partner_df['captured_pre'].astype(bool).any():
+        logger.error("No upstream bodies in the capture set defined by 'capture-statuses'.")
+        logger.error("Skipping downstream capture histogram.")
+        return
+
+    if not partner_df['captured_post'].astype(bool).any():
+        logger.error("No downstream bodies in the capture set defined by 'capture-statuses'.")
+        logger.error("Skipping downstream capture histogram.")
+        return
+
     _name = '-'.join(name.split())
     os.makedirs(f"reports/{roiset}/reports/{_name}", exist_ok=True)
 


### PR DESCRIPTION
In the neuprint `meta` configuration, there's a section for specifying the neuprint `roiHierarchy`.  Since the hierarchies can be rather complex and verbose, the implementation allows us to outsource some or all of the hierarchy specification to an external file(s).

Unfortunately, that functionality wasn't very well tested.  I ran into some issues when constructing the zebrafish ROI hierarchy.  This fixes them.

Also, this PR includes an unrelated commit to avoid a crash during report generation if there's nothing to report.

cc @StephanPreibisch @robsv 