### PR TITLE
neuprint: Select integer type based on the max value in the column.

### DIFF
--- a/flyem_snapshot/outputs/neuprint/util.py
+++ b/flyem_snapshot/outputs/neuprint/util.py
@@ -78,8 +78,13 @@ def neo4j_type_suffix(series):
             "and give it an explicit foo:boolean header."
         )
         raise RuntimeError(msg)
+
     if np.issubdtype(series.dtype, np.integer):
-        return 'int'
+        if series.abs().max() < 2**31:
+            return 'int'
+        else:
+            return 'long'
+
     if np.issubdtype(series.dtype, np.floating):
         return 'float'
 


### PR DESCRIPTION
`neuprint.util.neo4j_type_suffix()`: Check the int max value before selecting 'int' vs 'long'

cc @robsv @StephanPreibisch