### PR TITLE
Sync development branch

### DIFF
--- a/flyem_snapshot/inputs/annotations.py
+++ b/flyem_snapshot/inputs/annotations.py
@@ -77,19 +77,13 @@ AnnotationsSchema = {
             "description":
                 "Point annotation datasets to use for populating properties on the :Neuron nodes.\n"
                 "Each item should look something like this:\n"
-                "- instance: <dvid-instance-name>\n"
-                "  column-name: <name>\n",
+                "- instance: nuclei-centroids\n"
+                "  column-name: soma_position\n"
+                "  extract-properties:\n"
+                "    radius: nucleus_radius\n",
             "type": "array",
             "items": PointAnnotationSchema,
-            "default": [
-                {
-                    "instance": "nuclei-centroids",
-                    "column-name": "soma_position",
-                    "extract-properties": {
-                        "radius": "nucleus_radius"
-                    }
-                }
-            ]
+            "default": []
         },
         "replace-values": {
             "description":

--- a/flyem_snapshot/inputs/neurotransmitters.py
+++ b/flyem_snapshot/inputs/neurotransmitters.py
@@ -387,6 +387,10 @@ def _compute_body_neurotransmitters(cfg, tbar_df, ann):
         gt_df = None
     else:
         gt_df = pd.read_csv(cfg['ground-truth'])
+
+        # If working with the male cns, the column might be different.
+        gt_df = gt_df.rename(columns={'mcns_type': 'cell_type'})
+
         if not {*gt_df.columns} >= {'cell_type', 'ground_truth'}:
             raise RuntimeError("Neurotransmitter ground-truth table does not supply the necessary columns.")
         if 'split' not in tbar_df:
@@ -723,6 +727,10 @@ def _set_body_exp_gt_based_columns(cfg, body_df):
 
     # Overwrite cases where experimental groundtruth is available.
     exp_df = pd.read_csv(path)
+    
+    # mcns might have special column name in the groundtruth table.
+    exp_df = exp_df.rename(columns={'mcns_type': 'cell_type'})
+
     exp_df = exp_df.rename(columns={'type': 'cell_type', 'ground_truth': 'consensus_nt'})
     exp_df = exp_df.rename(columns={c: camelcase_to_snakecase(c) for c in exp_df.columns})
     exp_df = exp_df.set_index('cell_type')

--- a/flyem_snapshot/inputs/rois.py
+++ b/flyem_snapshot/inputs/rois.py
@@ -453,6 +453,8 @@ def _load_roi_col(roiset_name, roi_ids, point_df):
             roi_ids['<unspecified>'] = 0
 
     if roiset_name in point_df.columns:
+        if point_df[roiset_name].dtype == 'category' and '<unspecified>' not in point_df[roiset_name].dtype.categories:
+            point_df[roiset_name] = point_df[roiset_name].cat.add_categories("<unspecified>")
         point_df[roiset_name] = point_df[roiset_name].fillna("<unspecified>")
 
         # If it's present, <unspecified> is always listed first.

--- a/flyem_snapshot/main.py
+++ b/flyem_snapshot/main.py
@@ -229,10 +229,11 @@ def main_impl(cfg):
         min_conf = cfg['inputs']['synapses']['min-confidence']
         export_neurotransmitters(cfg['outputs']['neurotransmitters'], tbar_nt, body_nt, nt_confusion, point_df)
         export_flat_connectome(cfg['outputs']['flat-connectome'], point_df, partner_df, ann, snapshot_tag, min_conf)
+        export_skeletons(cfg['outputs']['skeletons'], snapshot_tag, ann, pointlabeler)
         export_neuprint(cfg['outputs']['neuprint'], point_df, partner_df, element_tables, ann, body_sizes,
                         tbar_nt, body_nt, syn_roisets, element_roisets, pointlabeler)
         export_reports(cfg['outputs']['connectivity-reports'], point_df, partner_df, ann, snapshot_tag)
-        export_skeletons(cfg['outputs']['skeletons'], ann)
+
 
 class SynapsesWithRoiSerializer(SerializerBase):
 
@@ -478,7 +479,7 @@ def standardize_config(cfg, config_dir):
         output_ntcfg['dvid']['uuid'] = output_ntcfg['dvid']['uuid'] or uuid
         output_ntcfg['dvid']['neuronjson_instance'] = output_ntcfg['dvid']['neuronjson_instance'] or f"{dvidcfg['instance']}_annotations"
 
-        # By default, the skeleton dvid backport goes to the main dvid server/uuid.
+        # By default, the skeletons come from the main dvid server/uuid.
         skeletoncfg['dvid']['server'] = skeletoncfg['dvid']['server'] or dvidcfg['server']
         skeletoncfg['dvid']['uuid'] = skeletoncfg['dvid']['uuid'] or uuid
         skeletoncfg['dvid']['instance'] = skeletoncfg['dvid']['instance'] or f"{dvidcfg['instance']}_skeletons"

--- a/flyem_snapshot/outputs/meshes.py
+++ b/flyem_snapshot/outputs/meshes.py
@@ -1,0 +1,239 @@
+"""
+Export meshes from a DVID server. Files are written to meshes-{cfg_name}/single-res-meshes/
+"""
+from functools import partial
+import logging
+import os
+import re
+import copy
+
+import pandas as pd
+import numpy as np
+import requests.exceptions
+
+from neuclease import PrefixFilter
+from neuclease.dvid.keyvalue import fetch_key, fetch_keys
+from neuclease.util import compute_parallel, dump_json
+from ..util.checksum import checksum
+from ..caches import cached, SerializerBase
+
+logger = logging.getLogger(__name__)
+
+# TODO:
+#   - Need to provide resolution (in nanometers) in the config.
+#   - Allow parallel process count to be configured?
+#   - Allow user to narrow the set of meshes to export by including or excluding body statuses?
+
+SingleInstanceMeshSchema = {
+    "description":
+        "Settings for neuroglancer mesh export, from a DVID keyvalue instance "
+        "which already stores the meshes in neuroglancer single-resolution format.",
+    "type": "object",
+    "default": {},
+    "properties": {
+        "export-meshes": {
+            "description": "If true, export the meshes.",
+            "type": "boolean",
+            "default": False,
+        },
+        "dvid": {
+            "description": "DVID server/UUID and instance to export neuroglancer single-resolution meshes from.",
+            "type": "object",
+            "additionalProperties": False,
+            "default": {},
+            "properties": {
+                "server": {
+                    "type": "string",
+                    "default": ""
+                },
+                "uuid": {
+                    "type": "string",
+                    "default": ""
+                },
+                "instance": {
+                    "type": "string",
+                    "default": ""
+                }
+            }
+        },
+        "exclude-statuses": {
+            "description": "List of body statuses to exclude from export.",
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "default": ["Unimportant", "Glia"]
+        }
+    }
+}
+
+MeshesSchema = {
+    "description": "Settings for exporting one or more mesh instances from DVID.",
+    "type": "object",
+    "default": {},
+    "properties": {
+        "processes": {
+            "description":
+                "How many processes should be used to export meshes?\n"
+                "If not specified, default to the top-level config setting.\n",
+            "type": ["integer", "null"],
+            "default": None
+        },
+    },
+    "additionalProperties": SingleInstanceMeshSchema,
+}
+
+
+def export_meshes(cfg, snapshot_tag, ann=None, pointlabeler=None):
+    cfg = copy.copy(cfg)
+    processes = cfg['processes']
+    del cfg['processes']
+    for name, instance_cfg in cfg.items():
+        export_mesh_instance(name, instance_cfg, snapshot_tag, ann, pointlabeler, processes=processes)
+
+
+class MeshSerializer(SerializerBase):
+    """
+    Serializer that just stores the table of exported meshes vs. missing meshes.
+    Avoids downloading meshes repeatedly for a release snapshot whose segmentation hasn't changed,
+    but attempts to re-export meshes that weren't successfully exported in the last run.
+    """
+
+    def get_cache_key(self, cfg_name, cfg, snapshot_tag, ann, pointlabeler=None, subset_bodies=None, processes=0):
+        self.cfg_name = cfg_name
+        self.cfg = cfg
+        self.snapshot_tag = snapshot_tag
+        self.ann = ann
+        self.pointlabeler = pointlabeler
+        self.processes = processes
+        cfg_hash = hex(checksum(cfg))
+
+        if ann is not None:
+            ann_body_hash = hex(checksum(np.sort(ann.index.values)))
+        else:
+            ann_body_hash = '0x0'
+
+        if pointlabeler is None:
+            mutid = 0
+        else:
+            mutid = pointlabeler.last_mutation["mutid"]
+
+        return f'{snapshot_tag}-seg-{mutid}-ann-{ann_body_hash}-{self.name}-{cfg_hash}.csv'
+
+    def save_to_file(self, results, path):
+        if results is None and os.path.exists(path):
+            os.remove(path)
+            return
+
+        results.to_csv(path, index=True, header=True)
+        if not results['success'].all():
+            num_failed = (~results['success']).sum()
+            logger.warning(
+                f"Failed to export meshes for {num_failed} body IDs. See {os.path.abspath(path)}"
+            )
+
+    def load_from_file(self, path):
+        results = pd.read_csv(path)
+        if not results['success'].all():
+            failed_bodies = results.loc[~results['success']].index.str[:-len('.ngmesh')].map(int).unique()
+            new_results = export_meshes(
+                self.cfg_name,
+                self.cfg,
+                self.snapshot_tag,
+                self.ann,
+                self.pointlabeler,
+                failed_bodies,
+                processes=self.processes
+            )
+            results.loc[new_results.index, 'success'] = new_results['success']
+        return results
+
+
+@PrefixFilter.with_context('meshes-{cfg_name}')
+@cached(MeshSerializer('meshes-{cfg_name}'))
+def export_mesh_instance(cfg_name, cfg, snapshot_tag, ann, pointlabeler=None, subset_bodies=None, processes=0):
+    """
+    Export neuroglancer precomputed single-resolution meshes from a DVID keyvalue instance.
+    The set of meshes to export is taken from the body annotations table.
+
+    The MeshSerializer ensures that we don't rerun the full export if it's already been
+    completed, but it does call this function if there are missing meshes from the last run.
+    """
+    del snapshot_tag
+    del pointlabeler
+
+    mesh_src = (
+        cfg['dvid']['server'],
+        cfg['dvid']['uuid'],
+        cfg['dvid']['instance'],
+    )
+    if not (cfg['export-meshes'] and all(mesh_src)):
+        return None
+
+    if subset_bodies is not None:
+        logger.info(f"Exporting meshes for a subset of {len(subset_bodies)} bodies")
+        keys = [f'{body}.ngmesh' for body in subset_bodies]
+    elif ann is None:
+        logger.info(f"Fetching all keys from {'/'.join(mesh_src)}")
+        keys = fetch_keys(*mesh_src)
+        keys = [k for k in keys if re.match(r"\d+.ngmesh$", k)]
+        if not keys:
+            logger.warning(
+                "Not exporting meshes: No mesh keys found in the DVID instance "
+                f"({'/'.join(mesh_src)})"
+            )
+            return
+    elif len(ann) == 0:
+        raise RuntimeError("Can't export meshes: No body IDs in the annotations table.")
+    else:
+        exclude_statuses = cfg['exclude-statuses']
+        ann = ann.query('status not in @exclude_statuses')
+        assert ann.index.name == 'body'
+        keys = ann.index.astype(str) + ".ngmesh"
+
+    dirname = f'meshes-{cfg_name}/single-res-meshes'
+    os.makedirs(f'{dirname}', exist_ok=True)
+    with open(f'{dirname}/info', 'w', encoding='utf-8') as f:
+        f.write('{"@type": "neuroglancer_legacy_mesh"}\n')
+
+    logger.info(f"Exporting meshes for {len(keys)} body IDs")
+
+    results = compute_parallel(
+        partial(_process_single_mesh, *mesh_src, dirname),
+        keys,
+        processes=processes,
+    )
+    results = pd.DataFrame(results, columns=['key', 'success']).set_index('key')
+    return results
+
+
+def _process_single_mesh(server, uuid, instance, dirname, key):
+    """
+    Fetch a single mesh from the DVID server.
+    Writes the mesh and also the appropriate pointer JSON file for the mesh e.g. "123:0"
+
+    Returns:
+        (key, success) tuple, where success is True if the mesh
+        exists on the DVID server and was written successfully.
+    """
+    assert key.endswith('.ngmesh')
+    body = key[:-len('.ngmesh')]
+
+    try:
+        mesh_bytes = fetch_key(server, uuid, instance, key)
+    except requests.exceptions.HTTPError:
+        return key, False
+    except Exception as e:
+        logger.warning(f"An exception of type {type(e).__name__} occurred. Arguments:\n{e.args}")
+        return key, False
+
+    if not mesh_bytes:
+        return key, False
+
+    fname = f"{dirname}/{body}.ngmesh"
+    with open(fname, "wb") as f:
+        f.write(mesh_bytes)
+
+    dump_json({"fragments": [f"{body}.ngmesh"]}, f"{dirname}/{body}:0")
+
+    return key, True

--- a/flyem_snapshot/outputs/neuprint/annotations.py
+++ b/flyem_snapshot/outputs/neuprint/annotations.py
@@ -73,6 +73,7 @@ NEUPRINT_STATUSLABEL_TO_STATUS = {
 
     'Anchor':                   'Anchor',       # noqa
     'Cleaved Anchor':           'Anchor',       # noqa
+    'Will be merged':           'Anchor',       # noqa
     'Sensory Anchor':           'Anchor',       # noqa
     'Cervical Anchor':          'Anchor',       # noqa
     'Soma Anchor':              'Anchor',       # noqa
@@ -81,6 +82,7 @@ NEUPRINT_STATUSLABEL_TO_STATUS = {
 
     'Leaves':                   'Traced',       # noqa
     'PRT Orphan':               'Traced',       # noqa
+    'Reviewed':                 'Traced',       # noqa
     'Prelim Roughly traced':    'Traced',       # noqa
     'RT Hard to trace':         'Traced',       # noqa
     'RT Orphan':                'Traced',       # noqa

--- a/flyem_snapshot/outputs/neuprint/annotations.py
+++ b/flyem_snapshot/outputs/neuprint/annotations.py
@@ -138,6 +138,10 @@ def neuprint_segment_annotations(cfg, ann):
     # Drop categorical dtype for this column before using replace()
     ann['statusLabel'] = ann['statusLabel'].astype('string')
 
+    # Neuprint uses 'simplified' status choices,
+    # referring to the original (dvid) status as 'statusLabel'.
+    ann['status'] = ann['statusLabel'].replace(NEUPRINT_STATUSLABEL_TO_STATUS)
+
     # Erase any values which are just "".
     # Better to leave them null.
     ann = ann.replace(["", pd.NA], [None, None])
@@ -148,10 +152,6 @@ def neuprint_segment_annotations(cfg, ann):
     if len(empty_cols) > 0:
         logger.info(f"Deleting empty annotation columns: {empty_cols.tolist()}")
         ann = ann.drop(columns=empty_cols)
-
-    # Neuprint uses 'simplified' status choices,
-    # referring to the original (dvid) status as 'statusLabel'.
-    ann['status'] = ann['statusLabel'].replace(NEUPRINT_STATUSLABEL_TO_STATUS)
 
     # Points must be converted to neo4j spatial points.
     # FIXME: What about point-annotations which DON'T contain 'location' or 'position' in the name?

--- a/flyem_snapshot/outputs/neuprint/annotations.py
+++ b/flyem_snapshot/outputs/neuprint/annotations.py
@@ -93,7 +93,7 @@ NEUPRINT_STATUSLABEL_TO_STATUS = {
 }
 
 
-def neuprint_segment_annotations(cfg, ann):
+def neuprint_segment_annotations(cfg, ann, convert_points_to_neo4j_spatial=True):
     """
     Translate input body annotations (e.g. clio annotations)
     to neuprint terminology and values.
@@ -114,7 +114,7 @@ def neuprint_segment_annotations(cfg, ann):
         if 'Position' in c
     })
     renames.update(CLIO_TO_NEUPRINT_PROPERTIES)
-    renames.update(cfg['annotation-property-names'])
+    renames.update(cfg.get('annotation-property-names', {}))
 
     # Drop the columns that map to "", and rename the rest.
     renames = {k:v for k,v in renames.items() if (k in ann) and v}
@@ -152,6 +152,9 @@ def neuprint_segment_annotations(cfg, ann):
     if len(empty_cols) > 0:
         logger.info(f"Deleting empty annotation columns: {empty_cols.tolist()}")
         ann = ann.drop(columns=empty_cols)
+
+    if not convert_points_to_neo4j_spatial:
+        return ann
 
     # Points must be converted to neo4j spatial points.
     # FIXME: What about point-annotations which DON'T contain 'location' or 'position' in the name?

--- a/flyem_snapshot/outputs/neuprint/meta.py
+++ b/flyem_snapshot/outputs/neuprint/meta.py
@@ -156,6 +156,10 @@ NeuronColumnSchema = {
         #     "type": "boolean",
         #     "default": False
         # },
+        "searchable": {
+            "type": "boolean",
+            "default": True
+        },
         "choices": {
             "description":
                 "Auto-complete choices for this property.\n"
@@ -668,10 +672,11 @@ def _load_neuron_columns(metacfg, neuron_df):
             logger.error(f"Meta config lists column '{col}' which is not present in the data.")
             continue
         if item['choices'] == 'auto':
+            item['choices'] = sorted(neuron_df[col].dropna().unique())
             # Note:
             #   Empty strings were already removed when the annotations
             #   were prepped for neuprint, so none of these choices will be "".
-            item['choices'] = sorted(neuron_df[col].dropna().unique())
+            assert "" not in item['choices']
     return neuron_columns
 
 

--- a/flyem_snapshot/outputs/neuprint/meta.py
+++ b/flyem_snapshot/outputs/neuprint/meta.py
@@ -676,7 +676,7 @@ def _load_neuron_columns(metacfg, neuron_df):
             # Note:
             #   Empty strings were already removed when the annotations
             #   were prepped for neuprint, so none of these choices will be "".
-            assert "" not in item['choices']
+            assert "" not in item['choices'], f"Empty string in choices for column '{col}'"
     return neuron_columns
 
 

--- a/flyem_snapshot/outputs/neuprint/neuprint.py
+++ b/flyem_snapshot/outputs/neuprint/neuprint.py
@@ -157,10 +157,20 @@ NeuprintSchema = {
                     "default": ["rootLocation", "somaLocation", "class", "type", "instance", "group", "somaSide", "synonyms"],
                 },
                 "status": {
-                    "description": "Segments with one of these neuprint statuses will be labeled Neurons\n",
+                    "description":
+                    "Segments with one of these neuprint statuses will be labeled Neurons.\n"
+                    "Note: These should be neuprint 'status' values, not 'statusLabel' values.",
                     "type": "array",
                     "items": {"type": "string"},
                     "default": ["Traced", "Anchor"],
+                },
+                "excluded-status": {
+                    "description":
+                        "Segments with one of these neuprint statuses will NOT be labeled as Neurons, regardless of their other properties.\n"
+                        "Note: These should be neuprint 'status' values, not 'statusLabel' values.",
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "default": ["Unimportant", "Glia"],
                 }
             }
         },

--- a/flyem_snapshot/outputs/neuprint/segment.py
+++ b/flyem_snapshot/outputs/neuprint/segment.py
@@ -440,6 +440,8 @@ def _assign_segment_label(cfg, neuron_df):
     is_neuron |= neuron_df[[*crit_props]].notnull().any(axis=1)
     is_neuron |= neuron_df['status'].isin(crit['status'])
 
+    is_neuron &= ~neuron_df['status'].isin(crit['excluded-status'])
+
     neuron_df[':LABEL'] = f'Segment;{dataset}_Segment'
     neuron_df.loc[is_neuron, ':LABEL'] = f'Segment;{dataset}_Segment;Neuron;{dataset}_Neuron'
 

--- a/flyem_snapshot/outputs/reports.py
+++ b/flyem_snapshot/outputs/reports.py
@@ -528,16 +528,19 @@ def _export_downstream_capture_histogram(cfg, snapshot_tag, roiset, name, partne
 
     # We're only interested in the downstream capture of
     # upstream bodies which are themselves in the capture set.
+    partner_df = partner_df.loc[partner_df['captured_pre'].astype(bool)]
     df = (
         partner_df
-        .query('captured_pre')
-        .groupby('body_pre')['captured_post'].value_counts()
+        [['body_pre', 'captured_post']].value_counts()
         .unstack()
         .fillna(0.0)
         .astype(np.int32)
     )
     df = df.rename(columns={True: 'captured', False: 'not_captured'})
     df.columns.name = None
+
+    df['downstream'] = df['captured'] + df['not_captured']
+    df['presyn'] = partner_df.groupby('body_pre')['pre_id'].nunique()
 
     df['capture_frac'] = (df['captured'] / (df['captured'] + df['not_captured'])).astype(np.float32)
 

--- a/flyem_snapshot/outputs/skeletons.py
+++ b/flyem_snapshot/outputs/skeletons.py
@@ -10,8 +10,10 @@ from functools import partial
 import logging
 import os
 import re
+import copy
 
 import pandas as pd
+import numpy as np
 import requests.exceptions
 
 from neuclease import PrefixFilter
@@ -19,6 +21,8 @@ from neuclease.dvid.keyvalue import fetch_key, fetch_keys
 from neuclease.util import (
     compute_parallel, skeleton_to_neuroglancer, swc_to_dataframe
 )
+from ..util.checksum import checksum
+from ..caches import cached, SerializerBase
 
 logger = logging.getLogger(__name__)
 
@@ -56,9 +60,116 @@ SkeletonSchema = {
                     "default": ""
                 }
             }
-        }
+        },
+        "processes": {
+            "description":
+                "How many processes should be used to export skeletons?\n"
+                "If not specified, default to the top-level config setting.\n",
+            "type": ["integer", "null"],
+            "default": None
+        },
     }
 }
+
+class SkeletonSerializer(SerializerBase):
+    """
+    Serializer that just stores the table of exported skeletons vs. missing skeletons.
+    Avoids downloading skeletons repeatedly for a release snapshot whose segmentation hasn't changed,
+    but attempts to re-export skeletons that weren't successfully exported in the last run.
+    """
+
+    def get_cache_key(self, cfg, snapshot_tag, ann=None, pointlabeler=None, subset_bodies=None):
+        self.cfg = cfg
+        self.snapshot_tag = snapshot_tag
+        self.ann = ann
+        self.pointlabeler = pointlabeler
+
+        cfg = copy.copy(cfg)
+        cfg['processes'] = 0
+
+        cfg_hash = hex(checksum(cfg))
+
+        if ann is not None:
+            ann_body_hash = hex(checksum(np.sort(ann.index.values)))
+        else:
+            ann_body_hash = '0x0'
+
+        if pointlabeler is None:
+            mutid = 0
+        else:
+            mutid = pointlabeler.last_mutation["mutid"]
+
+        return f'{snapshot_tag}-seg-{mutid}-ann-{ann_body_hash}-skeletons-{cfg_hash}.csv'
+
+    def save_to_file(self, results, path):
+        results.to_csv(path, index=True, header=True)
+        if not results['success'].all():
+            num_failed = (~results['success']).sum()
+            logger.warning(
+                f"Failed to export skeletons for {num_failed} body IDs. See {path}"
+            )
+
+    def load_from_file(self, path):
+        results = pd.read_csv(path)
+        if not results['success'].all():
+            failed_bodies = results.loc[~results['success']].index.str[:-4].map(int).unique()
+            new_results = export_skeletons(self.cfg, self.snapshot_tag, self.ann, self.pointlabeler, failed_bodies)
+            results.loc[new_results.index, 'success'] = new_results['success']
+        return results
+
+
+@PrefixFilter.with_context('skeletons')
+@cached(SkeletonSerializer('skeletons'))
+def export_skeletons(cfg, snapshot_tag, ann=None, pointlabeler=None, subset_bodies=None):
+    """
+    Export skeletons in both SWC and Neuroglancer precomputed format.
+    The set of skeletons to export is taken from the body annotations table.
+    """
+    del snapshot_tag
+    del pointlabeler
+
+    skeleton_src = (
+        cfg['dvid']['server'],
+        cfg['dvid']['uuid'],
+        cfg['dvid']['instance'],
+    )
+    if not (cfg['export-skeletons'] and all(skeleton_src)):
+        return
+
+    if subset_bodies is not None:
+        logger.info(f"Exporting skeletons for a subset of {len(subset_bodies)} bodies")
+        keys = [f'{body}_swc' for body in subset_bodies]
+    elif ann is None:
+        logger.info(f"Fetching all keys from {'/'.join(skeleton_src)}")
+        keys = fetch_keys(*skeleton_src)
+        keys = [k for k in keys if re.match(r"\d+_swc$", k)]
+        if not keys:
+            logger.warning(
+                "Not exporting skeletons: No skeleton keys found in the DVID instance "
+                f"({'/'.join(skeleton_src)})"
+            )
+            return
+    elif len(ann) == 0:
+        logger.warning("Not exporting skeletons: No body IDs in the annotations table.")
+        return
+    else:
+        assert ann.index.name == 'body'
+        keys = ann.index.astype(str) + "_swc"
+
+    os.makedirs('skeletons/skeletons-swc', exist_ok=True)
+    os.makedirs('skeletons/skeletons-precomputed', exist_ok=True)
+    with open('skeletons/skeletons-precomputed/info', 'w', encoding='utf-8') as f:
+        f.write('{"@type": "neuroglancer_skeletons"}\n')
+
+    logger.info(f"Processing skeletons for {len(keys)} body IDs")
+
+    results = compute_parallel(
+        partial(_process_single_skeleton, *skeleton_src),
+        keys,
+        processes=cfg['processes'],
+    )
+    results = pd.DataFrame(results, columns=['key', 'success']).set_index('key')
+    return results
 
 
 def _process_single_skeleton(server, uuid, instance, key):
@@ -96,60 +207,6 @@ def _process_single_skeleton(server, uuid, instance, key):
     skeleton_to_neuroglancer(df, output_path=f"skeletons/skeletons-precomputed/{body}")
     return key, True
 
-
-@PrefixFilter.with_context('skeletons')
-def export_skeletons(cfg, ann=None):
-    """
-    Export skeletons in both SWC and Neuroglancer precomputed format.
-    The set of skeletons to export is taken from the body annotations table.
-    """
-    skeleton_src = (
-        cfg['dvid']['server'],
-        cfg['dvid']['uuid'],
-        cfg['dvid']['instance'],
-    )
-    if not (cfg['export-skeletons'] and all(skeleton_src)):
-        return
-
-    if ann is None:
-        logger.info(f"Fetching all keys from {'/'.join(skeleton_src)}")
-        keys = fetch_keys(*skeleton_src)
-        keys = [k for k in keys if re.match(r"\d+_swc$", k)]
-        if not keys:
-            logger.warning(
-                "Not exporting skeletons: No skeleton keys found in the DVID instance "
-                f"({'/'.join(skeleton_src)})"
-            )
-            return
-    elif len(ann) == 0:
-        logger.warning("Not exporting skeletons: No body IDs in the annotations table.")
-        return
-    else:
-        assert ann.index.name == 'body'
-        keys = ann.index.astype(str) + "_swc"
-
-    os.makedirs('skeletons/skeletons-swc', exist_ok=True)
-    os.makedirs('skeletons/skeletons-precomputed', exist_ok=True)
-    with open('skeletons/skeletons-swc/info', 'w', encoding='utf-8') as f:
-        f.write('{"@type": "neuroglancer_skeletons"}\n')
-
-    logger.info(f"Processing skeletons for {len(keys)} body IDs")
-
-    results = compute_parallel(
-        partial(_process_single_skeleton, *skeleton_src),
-        keys,
-        processes=8,
-        show_progress=False,
-    )
-    results = pd.DataFrame(results, columns=['key', 'success'])
-
-    if not results['success'].all():
-        missing_keys = results.loc[~results['success'], 'key']
-        missing_keys.to_csv('skeletons/missing-skeletons.csv', index=False, header=True)
-        logger.warning(
-            f"Did not find skeletons for {len(missing_keys)} body IDs from the annotations. "
-            "See skeletons/missing-skeletons.csv."
-        )
 
 # Command-line entry point for testing with hemibrain (no annotations)
 if __name__ == "__main__":


### PR DESCRIPTION
- skeletons:
    - Now accepts a *list* of skeleton configurations to export (e.g. for the main skeleton instance and for mirrored skeletons)
    - Use a custom serializer to avoid re-running the export for bodies which already have a skeleton (as long as the rest of the relevant config and segmentation version haven't changed since the last run).
    - Auto-set the skeleton resolution according to the DVID metadata from the segmentation instance
- mesh: We now export meshes from DVID (in very similar fashion to skeletons)
- neuprint:
    - New option `excluded-status` to exclude certain bodies from becoming `:Neuron` nodes according to their `status`.  Defaults to `["Unimportant", "Glia"]`.
        - Fixes #23
    - Explicit support recently introduced body statuses: `Reviewed` and `Will be merged`
    - neuprint.meta: Added `searchable` option (now supported in neuprintExplorer)
        - See https://github.com/connectome-neuprint/neuPrintExplorer/pull/365
    - bug fix: Apply statusLabel translations _before_ deleting empty strings, to ensure no empty strings remain in the final output.
- neurotransmitters:
    -  If a body had _any_ tbars in the training set, we exclude all of its tbars from the confusion calculation
- flat-connectome: Export the body annotation table to the `flat-connectome` directory
- annotations: Don't list any point annotation instances in the default config
- serializers/caching: Now serializers can be named according to a parameter in the decorated function (using a format string pattern in the serializer name).
- dvidseg: Avoid re-exporting the labelmap mapping if the segmentation hasn't changed since the last run.
- rois: Minor robustness enhancements to ROI loading
- reports: Minor enhancements

cc @robsv @StephanPreibisch