### PR TITLE
Elements from dvid

### DIFF
--- a/flyem_snapshot/inputs/annotations.py
+++ b/flyem_snapshot/inputs/annotations.py
@@ -22,6 +22,7 @@ _ = hvplot.pandas  # for linting
 
 logger = logging.getLogger(__name__)
 
+# Note: Also used in elements.ElementTableSchema
 PointAnnotationSchema = {
     "description": "Settings to describe a source of point annotations in DVID which should be associated with each body.",
     "type": "object",
@@ -32,6 +33,7 @@ PointAnnotationSchema = {
         "instance": {
             "description":
                 "Name of the DVID annotation instance which contains the points.\n"
+                "(The DVID server and UUID will be obtained from the main 'dvid-seg' config.)\n"
                 "Note: If more than one annotation point falls on the same body,\n"
                 "      only one will be used, and the others simply dropped.\n"
                 "Example: 'nuclei-centroids'\n",

--- a/flyem_snapshot/inputs/elements.py
+++ b/flyem_snapshot/inputs/elements.py
@@ -44,6 +44,13 @@ ElementTableSchema = {
                 "  extract-properties:\n"
                 "    radius: nucleus_radius\n",
         },
+        "permit-body-0": {
+            "description":
+                "If False, filter out any elements that reside on body 0.\n"
+                "Otherwise, leave them in, which means neuprint may include :Segment/:Neuron for body 0 and it will have elements.\n",
+            "type": "boolean",
+            "default": False,
+        },
         "type": {
             "description":
                 "Optional. Adds a column named 'type' to the table, with the given value in all rows.\n"
@@ -99,7 +106,12 @@ def load_elements(cfg, pointlabeler):
         if name == "processes":
             continue
 
-        point_df = _load_element_points(name, table_cfg, pointlabeler)
+        dvid_server = dvid_uuid = None
+        if pointlabeler:
+            dvid_server = pointlabeler.dvidseg.server
+            dvid_uuid = pointlabeler.dvidseg.uuid
+
+        point_df = _load_element_points(name, table_cfg, dvid_server, dvid_uuid)
         distance_df = _load_element_distances(name, table_cfg)
 
         if point_df is not None:
@@ -108,13 +120,16 @@ def load_elements(cfg, pointlabeler):
             pointlabeler.update_bodies_for_points(point_df, cfg['processes'])
             point_df = point_df.astype({'body': np.int64, 'sv': np.int64})
 
+        if not table_cfg['permit-body-0']:
+            point_df = point_df.loc[point_df['body'] != 0].copy()
+
         # FIXME: This would be more convenient to mutate if it were a DataClass.
         element_dfs[name] = (point_df, distance_df)
 
     return element_dfs
 
 
-def _load_element_points(name, table_cfg, pointlabeler):
+def _load_element_points(name, table_cfg, dvid_server, dvid_uuid):
     table_path = table_cfg['point-table']
     ann_instance = table_cfg['dvid-point-annotations']['instance']
 
@@ -128,7 +143,12 @@ def _load_element_points(name, table_cfg, pointlabeler):
         element_df = _load_element_points_from_table(name, table_path)
     if ann_instance:
         pa_cfg = table_cfg['dvid-point-annotations']
-        element_df = _load_element_points_from_dvid(name, pa_cfg, pointlabeler)
+        element_df = _load_element_points_from_dvid(
+            name,
+            pa_cfg,
+            dvid_server,
+            dvid_uuid
+        )
 
     if (cfg_type := table_cfg['type']):
         if 'type' in element_df.columns and (element_df['type'] != cfg_type).any():
@@ -162,11 +182,11 @@ def _load_element_points_from_table(name, table_path):
     return element_df
 
 
-def _load_element_points_from_dvid(name, pa_cfg, pointlabeler):
+def _load_element_points_from_dvid(name, pa_cfg, dvid_server, dvid_uuid):
     with Timer(f"Loading '{name}' elements from DVID instance '{pa_cfg['instance']}'", logger):
         df = fetch_all_elements(
-            pointlabeler.dvidseg.server,
-            pointlabeler.dvidseg.uuid,
+            dvid_server,
+            dvid_uuid,
             pa_cfg['instance'],
             format='pandas'
         )

--- a/flyem_snapshot/inputs/elements.py
+++ b/flyem_snapshot/inputs/elements.py
@@ -9,7 +9,7 @@ import pandas as pd
 import pyarrow.feather as feather
 
 from neuclease.util import Timer, encode_coords_to_uint64
-from neuclease.dvid import fetch_all_elements, fetch_labels_batched
+from neuclease.dvid import fetch_all_elements
 
 from .annotations import PointAnnotationSchema
 

--- a/flyem_snapshot/inputs/elements.py
+++ b/flyem_snapshot/inputs/elements.py
@@ -1,7 +1,7 @@
 """
 Import "elements" (point objects) from disk, filter them, and associate each point with a body ID.
 """
-import os
+import copy
 import logging
 
 import numpy as np
@@ -9,7 +9,12 @@ import pandas as pd
 import pyarrow.feather as feather
 
 from neuclease.util import Timer, encode_coords_to_uint64
+from neuclease.dvid import fetch_all_elements, fetch_labels_batched
 
+from .annotations import PointAnnotationSchema
+
+ElementPointAnnotationSchema = copy.deepcopy(PointAnnotationSchema)
+ElementPointAnnotationSchema['properties']['instance']['default'] = ""
 
 logger = logging.getLogger(__name__)
 
@@ -20,16 +25,29 @@ ElementTableSchema = {
     "properties": {
         "point-table": {
             "description":
-                "Optional. A feather or CSV file containing the element points, optionally with a 'body' column.\n"
+                "A feather or CSV file containing the element points, optionally with a 'body' column.\n"
                 "If an 'sv' column is also present, it can be used to much more efficiently update the body column if needed.\n"
-                "Required columns are x,y,z,type.  Other columns may be present and will be loaded in neuprint outputs.\n",
+                "Required columns are x,y,z,type.  Other columns may be present and will be loaded in neuprint outputs.\n"
+                "(If your annotation points are stored in a DVID point annotation instance, use the point-annotations config instead of this.)\n",
             "type": "string",
             "default": ""
+        },
+        "dvid-point-annotations": {
+            **ElementPointAnnotationSchema,
+            "description":
+                "Point annotation dataset from DVID to use for populating properties on the :Element nodes.\n"
+                "(If your annotation points are stored in a CSV or feather file, use the point-table config instead of this.)\n"
+                "Should look something like this:\n"
+                "dvid-point-annotations:\n"
+                "  instance: nuclei-centroids\n"
+                "  column-name: soma_position\n"
+                "  extract-properties:\n"
+                "    radius: nucleus_radius\n",
         },
         "type": {
             "description":
                 "Optional. Adds a column named 'type' to the table, with the given value in all rows.\n"
-                "If no type is provided here in the config, then the data itself should have a type column.\n",
+                "If no type is provided here in the config, then the data itself should have a type column/property.\n",
             "type": "string",
             "default": "",
         },
@@ -54,7 +72,7 @@ ElementTableSchema = {
                     "type": "null"
                 }
             ]
-        },
+        }
     }
 }
 
@@ -81,7 +99,7 @@ def load_elements(cfg, pointlabeler):
         if name == "processes":
             continue
 
-        point_df = _load_element_points(name, table_cfg)
+        point_df = _load_element_points(name, table_cfg, pointlabeler)
         distance_df = _load_element_distances(name, table_cfg)
 
         if point_df is not None:
@@ -96,17 +114,21 @@ def load_elements(cfg, pointlabeler):
     return element_dfs
 
 
-def _load_element_points(name, table_cfg):
-    path = table_cfg['point-table']
-    if not path:
+def _load_element_points(name, table_cfg, pointlabeler):
+    table_path = table_cfg['point-table']
+    ann_instance = table_cfg['dvid-point-annotations']['instance']
+
+    if ann_instance and table_path:
+        raise RuntimeError(f"Element table '{name}' cannot use both a point-annotation instance and a point-table file.")
+
+    if not table_path and not ann_instance:
         return
-    os.makedirs('tables', exist_ok=True)
-    with Timer(f"Loading '{name}' elements from disk", logger):
-        assert path.split('.')[-1] in ('feather', 'csv')
-        if path.endswith('.csv'):
-            element_df = pd.read_csv(path)
-        else:
-            element_df = feather.read_feather(path)
+    
+    if table_path:
+        element_df = _load_element_points_from_table(name, table_path)
+    if ann_instance:
+        pa_cfg = table_cfg['dvid-point-annotations']
+        element_df = _load_element_points_from_dvid(name, pa_cfg, pointlabeler)
 
     if (cfg_type := table_cfg['type']):
         if 'type' in element_df.columns and (element_df['type'] != cfg_type).any():
@@ -130,12 +152,52 @@ def _load_element_points(name, table_cfg):
     return element_df
 
 
+def _load_element_points_from_table(name, table_path):
+    with Timer(f"Loading '{name}' elements from disk", logger):
+        assert table_path.split('.')[-1] in ('feather', 'csv')
+        if table_path.endswith('.csv'):
+            element_df = pd.read_csv(table_path)
+        else:
+            element_df = feather.read_feather(table_path)
+    return element_df
+
+
+def _load_element_points_from_dvid(name, pa_cfg, pointlabeler):
+    with Timer(f"Loading '{name}' elements from DVID instance '{pa_cfg['instance']}'", logger):
+        df = fetch_all_elements(
+            pointlabeler.dvidseg.server,
+            pointlabeler.dvidseg.uuid,
+            pa_cfg['instance'],
+            format='pandas'
+        )
+    df = df.sort_values([*'zyx'])
+
+    # Assign a column for each of the extracted point properties.
+    for prop, propcol in pa_cfg['extract-properties'].items():
+        if prop.lower() not in df:
+            logger.warning(f"Annotation instance {pa_cfg['instance']} contains no properties named '{prop}'")
+            continue
+
+        # DVID annotation properties are stored as strings,
+        # even if they would ideally be stored as int or float.
+        # Attempt to convert back to float if possible,
+        # otherwise leave as string.
+        try:
+            df[prop.lower()] = df[prop.lower()].astype(np.float32)
+        except ValueError:
+            logger.warning(f"Annotation instance {pa_cfg['instance']} contains non-numeric property '{prop}'; keeping as string.")
+
+        df[propcol] = df[prop.lower()]
+
+    df = df[[*'zyx', *pa_cfg['extract-properties'].values()]]
+    return df
+
+
 def _load_element_distances(name, table_cfg):
     path = table_cfg['distance-table']
     if not path:
         return
 
-    os.makedirs('tables', exist_ok=True)
     with Timer(f"Loading '{name}' distances from disk", logger):
         distance_df = feather.read_feather(path)
         required_cols = {

--- a/flyem_snapshot/inputs/synapses.py
+++ b/flyem_snapshot/inputs/synapses.py
@@ -91,6 +91,15 @@ SnapshotSynapsesSchema = {
             "maximum": 1.0,
             "default": 0.0,
         },
+        "permit-body-0": {
+            "description":
+                "If False, filter out any synapses that reside on body 0.\n"
+                "Otherwise, leave them in, which means neuprint may include :Segment/:Neuron for body 0 and it will have synapses.\n"
+                "Note: If your dataset also includes other 'Element' point tables (e.g. mito, soma, pin columns),\n"
+                "you can decide separately whether to permit body 0 for those.\n",
+            "type": "boolean",
+            "default": False,
+        },
         "roi-set-names": {
             "description":
                 "The list of ROI sets to include as columns in the synapse table.\n"
@@ -164,10 +173,10 @@ def load_synapses(cfg, snapshot_tag, pointlabeler):  # noqa
 
     point_df, partner_df = _filter_for_zone(point_df, partner_df, cfg['zone'])
     point_df, partner_df = _filter_for_confidence(point_df, partner_df, cfg['min-confidence'])
+    point_df, partner_df = _update_body_columns(point_df, partner_df, pointlabeler, cfg['permit-body-0'], cfg['processes'])
     point_df, partner_df = _filter_for_self_consistency(point_df, partner_df)
     logger.info(f"Kept {len(point_df)} points and {len(partner_df)} partners after filtering")
 
-    point_df, partner_df = _update_body_columns(point_df, partner_df, pointlabeler, cfg['processes'])
     return point_df, partner_df
 
 
@@ -366,7 +375,7 @@ def _filter_for_self_consistency(point_df, partner_df):
     return point_df.copy(), partner_df.copy()
 
 
-def _update_body_columns(point_df, partner_df, pointlabeler, processes):
+def _update_body_columns(point_df, partner_df, pointlabeler, permit_body_0, processes):
     if pointlabeler:
         with Timer(f"Updating supervoxels/bodies for UUID {pointlabeler.dvidseg.uuid[:6]}", logger):
             pointlabeler.update_bodies_for_points(point_df, processes=processes)
@@ -381,5 +390,11 @@ def _update_body_columns(point_df, partner_df, pointlabeler, processes):
         partner_df = partner_df.drop(columns=['body_pre', 'body_post'], errors='ignore')
         partner_df = partner_df.merge(point_df['body'], 'left', left_on='pre_id', right_index=True)
         partner_df = partner_df.merge(point_df['body'], 'left', left_on='post_id', right_index=True, suffixes=['_pre', '_post'])
+
+    if not permit_body_0:
+        point_df = point_df.loc[point_df['body'] != 0].copy()
+        partner_df = partner_df.loc[
+            (partner_df['body_pre'] != 0) & (partner_df['body_post'] != 0)
+        ].copy()
 
     return point_df, partner_df

--- a/flyem_snapshot/outputs/neuprint/annotations.py
+++ b/flyem_snapshot/outputs/neuprint/annotations.py
@@ -10,6 +10,8 @@ import pandas as pd
 from neuclease.util import snakecase_to_camelcase
 from neuclease.dvid.keyvalue import DEFAULT_BODY_STATUS_CATEGORIES
 
+from .util import convert_point_cols_to_neo4j_spatial
+
 logger = logging.getLogger(__name__)
 
 # For most fields, we formulaically convert from snake_case to camelCase,
@@ -172,94 +174,9 @@ def neuprint_segment_annotations(cfg, ann, convert_points_to_neo4j_spatial=True)
         logger.info(f"Deleting empty annotation columns: {empty_cols.tolist()}")
         ann = ann.drop(columns=empty_cols)
 
-    if not convert_points_to_neo4j_spatial:
-        return ann
-
-    # Points must be converted to neo4j spatial points.
-    # FIXME: What about point-annotations which DON'T contain 'location' or 'position' in the name?
-    for col in ann.columns:
-        if not re.search('position|location', col.lower()):
-            continue
-
-        # FIXME: Is there a better way to catch positionType instead of hard-coding this?
-        if col in ('positionType', 'locationType'):
-            continue
-
-        count = ann[col].notnull().sum()
-        ann[col] = ann[col].map(_convert_point)
-        newcount = ann[col].notnull().sum()
-        if newcount != count:
-            logger.warning(
-                f"Point annotation column {col} has {count - newcount}"
-                " values which could not be processed as points."
-            )
-
-        valid = ann[col].notnull()
-        ann.loc[~valid, col] = None
-        ann.loc[valid, col] = [
-            f"{{x:{x}, y:{y}, z:{z}}}"
-            for (x,y,z) in ann.loc[valid, col].values
-        ]
+    if convert_points_to_neo4j_spatial:
+        # Convert '.*location.*' and '.*position.*' columns to neo4j spatial points.
+        # FIXME: What about point-annotations which DON'T contain 'location' or 'position' in the name?
+        convert_point_cols_to_neo4j_spatial(ann)
 
     return ann
-
-
-def _convert_point(p):
-    """
-    Convert the given entity from various possible forms of point data into to a standard form.
-
-    The input may be one of the following:
-
-    - A string like '123, 456, 789'
-    - A string like '[123, 456, 789]'
-    - A string like '{x: 123, y: 456, z: 789}'
-    - A list or array of three ints or floats
-    - a neo4j spatial coordinate like this:
-        {
-            'coordinates': [24481, 36044, 67070],
-            'crs': {'name': 'cartesian-3d',
-            'properties': {'href': 'http://spatialreference.org/ref/sr-org/9157/ogcwkt/',
-            'type': 'ogcwkt'},
-            'srid': 9157,
-            'type': 'link'},
-            'type': 'Point'
-        }
-
-    The output form is just a list: [x, y, z].
-    If the input is None or cannot be interpreted as a point, then None is returned.
-    """
-    match p:
-        case None:
-            return None
-
-        case {'coordinates': coords} if len(coords) == 3:
-            return coords
-
-        case {'x': x, 'y': y, 'z': z}:
-            return [x, y, z]
-
-        case [x, y, z] if all(isinstance(v, int) for v in (x, y, z)):
-            return [x, y, z]
-
-        case [x, y, z]:
-            try:
-                return [float(x), float(y), float(z)]
-            except (ValueError, TypeError):
-                return None
-
-        case str() as s:
-            s = s.strip('[]{} ')
-
-            try:
-                pattern = (
-                    r'(?:x:\s*)?(-?\d+\.?\d*)\s*,\s*'
-                    r'(?:y:\s*)?(-?\d+\.?\d*)\s*,\s*'
-                    r'(?:z:\s*)?(-?\d+\.?\d*)\s*$'
-                )
-                if match := re.match(pattern, s):
-                    return [eval(x) for x in match.groups()]
-            except (ValueError, TypeError):
-                return None
-
-        case _:
-            return None

--- a/flyem_snapshot/outputs/neuprint/annotations.py
+++ b/flyem_snapshot/outputs/neuprint/annotations.py
@@ -119,7 +119,7 @@ def neuprint_segment_annotations(cfg, ann, convert_points_to_neo4j_spatial=True)
         else:
             raise ValueError("Body annotations table must have a 'body' column or index.")
 
-    ann = ann.query('body != 0')
+    ann = ann.query('body != 0').copy()
 
     # Note that dvid/clio neuronjson annotations come with the bodyid column,
     # but annotations loaded from CSV or from dvid point annotations don't

--- a/flyem_snapshot/outputs/neuprint/element.py
+++ b/flyem_snapshot/outputs/neuprint/element.py
@@ -9,7 +9,8 @@ import pandas as pd
 from neuclease import PrefixFilter
 from neuclease.util import timed, compute_parallel
 
-from .util import neo4j_column_names, append_neo4j_type_suffixes
+from ...util.util import replace_object_nan_with_none
+from .util import neo4j_column_names, append_neo4j_type_suffixes, convert_point_cols_to_neo4j_spatial
 
 logger = logging.getLogger(__name__)
 
@@ -91,6 +92,13 @@ def _export_neuprint_elements(cfg, point_df, roisets, *, config_name):
     logger.info(f"Non-ROI properties: {prop_cols}")
     logger.info(f"ROI properties from the following roi-sets: {roisets}")
     point_df = append_neo4j_type_suffixes(point_df, exclude=(*'xyz', *roicols))
+
+    replace_object_nan_with_none(point_df)
+
+    # Convert properties such as 'closestLandmarkLocation' from values like "[123, 456, 789]"
+    # to the string format required for neo4j spatial points in CSV files,
+    # e.g. "{x: 123, y: 456, z: 789}"
+    convert_point_cols_to_neo4j_spatial(point_df)
 
     export_subdir = f'neuprint/Neuprint_Elements/{config_name}'
     os.makedirs(export_subdir, exist_ok=True)

--- a/flyem_snapshot/outputs/neuprint/element.py
+++ b/flyem_snapshot/outputs/neuprint/element.py
@@ -15,7 +15,7 @@ from .util import neo4j_column_names, append_neo4j_type_suffixes, convert_point_
 logger = logging.getLogger(__name__)
 
 
-@PrefixFilter.with_context("Synapse")
+@PrefixFilter.with_context("Element")
 def export_neuprint_elements(cfg, element_tables, element_roisets):
     """
     Export generic (non-Synapse) Element nodes and relationships.

--- a/flyem_snapshot/outputs/neuprint/element.py
+++ b/flyem_snapshot/outputs/neuprint/element.py
@@ -10,7 +10,7 @@ from neuclease import PrefixFilter
 from neuclease.util import timed, compute_parallel
 
 from ...util.util import replace_object_nan_with_none
-from .util import neo4j_column_names, append_neo4j_type_suffixes, convert_point_cols_to_neo4j_spatial
+from .util import neo4j_column_names, append_neo4j_type_suffixes, convert_point_cols_to_neo4j_spatial, prepare_int_cols_for_export
 
 logger = logging.getLogger(__name__)
 
@@ -93,6 +93,7 @@ def _export_neuprint_elements(cfg, point_df, roisets, *, config_name):
     logger.info(f"ROI properties from the following roi-sets: {roisets}")
     point_df = append_neo4j_type_suffixes(point_df, exclude=(*'xyz', *roicols))
 
+    prepare_int_cols_for_export(point_df)
     replace_object_nan_with_none(point_df)
 
     # Convert properties such as 'closestLandmarkLocation' from values like "[123, 456, 789]"

--- a/flyem_snapshot/outputs/neuprint/element.py
+++ b/flyem_snapshot/outputs/neuprint/element.py
@@ -4,6 +4,8 @@ import logging
 import warnings
 from functools import partial
 
+import pandas as pd
+
 from neuclease import PrefixFilter
 from neuclease.util import timed, compute_parallel
 
@@ -55,12 +57,35 @@ def _export_neuprint_elements(cfg, point_df, roisets, *, config_name):
 
     # All non-ROI columns from the input table are exported as :Element properties.
     roicols = (*roisets, *(f'{c}_label' for c in roisets))
-    prop_cols = set(point_df.columns) - set(roicols) - {*'xyz', 'point_id'}
+    prop_cols = list(set(point_df.columns) - set(roicols) - {*'xyz', 'point_id'})
     roi_syn_props = {k:v for k,v in cfg['roi-synapse-properties'].items() if k in point_df.columns}
 
     point_df = point_df.rename(columns={
         'point_id': ':ID(Element-ID)'
     })
+
+    # Boolean columns require special representation for neo4j CSV
+    for c in prop_cols:
+        if (
+            point_df[c].dtype in (bool, object)
+            and len(u := point_df[c].dropna().unique()) <= 2  # noqa
+            and set(u) <= {True, False}                   # noqa
+        ):
+            point_df[c] = point_df[c].replace([True, False], ['true', 'false'])
+            point_df = point_df.rename(columns={c: f'{c}:boolean'})
+
+    # For float columns in which all non-null values are integers, convert
+    # to object or int so they'll be written to CSV without a decimal point.
+    for col in prop_cols:
+        if not pd.api.types.is_float_dtype(point_df[col]):
+            continue
+        not_null = point_df[col].notnull()
+        all_int = (point_df[col].dropna() % 1).all()
+        if not_null.all() and all_int:
+            point_df[col] = point_df[col].astype(int)
+        elif all_int:
+            point_df[col] = point_df[col].astype(object)
+            point_df.loc[not_null, col] = point_df.loc[not_null, col].astype(int)
 
     logger.info(f"Exporting {specific_label} Elements")
     logger.info(f"Non-ROI properties: {prop_cols}")

--- a/flyem_snapshot/outputs/neuprint/elementset.py
+++ b/flyem_snapshot/outputs/neuprint/elementset.py
@@ -11,20 +11,28 @@ logger = logging.getLogger(__name__)
 
 @PrefixFilter.with_context("ElementSet")
 @timed
-def export_neuprint_elementsets(cfg, element_tables, connectome):
-    synaptic_bodies = pd.concat(
-        (connectome['body_pre'].rename('body'),
-         connectome['body_post'].rename('body')), ignore_index=True).drop_duplicates()
+def export_neuprint_elementsets(cfg, element_tables, all_segment_ids):
     all_points = [points for points, _ in element_tables.values() if points is not None]
     if len(all_points) == 0 or sum(map(len, all_points)) == 0:
         return
 
     all_points = pd.concat(all_points)
     for elm_type, points in all_points.groupby('type'):
-        _export_elementsets(cfg, elm_type, points, synaptic_bodies)
+        _export_elementsets(cfg, elm_type, points, all_segment_ids)
 
 
-def _export_elementsets(cfg, elm_type, point_df, synaptic_bodies):
+def _export_elementsets(cfg, elm_type, point_df, all_segment_ids):
+    """
+    Export two CSV files for the given element type:
+
+    1. Neuprint_Neuron_to_ElementSet_{elm_type}.csv
+        - Defines :Segment-[:Contains]->:ElementSet edges
+    2. Neuprint_ElementSet_to_Element_{elm_type}.csv
+        - Defines :ElementSet-[:Contains]->:Element edges
+    
+    These files are used to construct the ':Contains' relationships
+    via ingest-neuprint-snapshot-within-neo4j-container.sh.    
+    """
     dataset = cfg['meta']['dataset']
     label = f"ElementSet;{dataset}_ElementSet"
 
@@ -50,16 +58,18 @@ def _export_elementsets(cfg, elm_type, point_df, synaptic_bodies):
     fname = f"Neuprint_Neuron_to_ElementSet_{elm_type}.csv"
     with Timer(f"Writing {fname}", logger):
         # Currently, neuprint does not create any :Segment nodes
-        # for non-synaptic bodies (including body 0).
-        # (We also discard all Synapses that fall on body 0.)
+        # for which have no synapses or body annotations (including body 0).
+        # (And even if they are annotated, non-synaptic bodies are only
+        # included if 'keep-non-synaptic-segments' is set in the config.)
+        # (Note that we also discard all Synapses that fall on body 0.)
         #
         # But generic Elements are intended to be versatile and serve
         # diverse use-cases, including those that don't require an
         # enclosing :Segment.
         #
         # Therefore, unlike synapses, we DO allow Elements to exist
-        # even if they come from non-synaptic bodies (including
-        # body 0).
+        # even if they come from non-synaptic,non-annotated bodies
+        # (including body 0).
         #
         # The only "catch" is that we must not create the edge
         # :Segment-[:Contains]->:ElementSet in such cases,
@@ -73,8 +83,7 @@ def _export_elementsets(cfg, elm_type, point_df, synaptic_bodies):
         #   (e.g. for Element ROI properties).
         (
             elmset_df.loc[
-                # Synaptic bodies only.
-                elmset_df['body'].isin(synaptic_bodies),
+                elmset_df['body'].isin(all_segment_ids),
                 ['body', 'elmset_id']
             ]
             .rename(columns={

--- a/flyem_snapshot/outputs/neuprint/neuprint.py
+++ b/flyem_snapshot/outputs/neuprint/neuprint.py
@@ -384,7 +384,7 @@ def export_neuprint(
     connectome = export_neuprint_segment_connections(cfg, partner_df)
 
     # TODO: It would be good to verify that there are no duplicated Element IDs (including Synapses)
-    export_neuprint_elementsets(cfg, element_tables, neuron_df.index)
+    export_neuprint_elementsets(cfg, element_tables, neuron_df[':ID(Body-ID)'].values)
     export_neuprint_elements(cfg, element_tables, element_roisets)
     export_neuprint_elements_closeto(element_tables)
 

--- a/flyem_snapshot/outputs/neuprint/neuprint.py
+++ b/flyem_snapshot/outputs/neuprint/neuprint.py
@@ -384,7 +384,7 @@ def export_neuprint(
     connectome = export_neuprint_segment_connections(cfg, partner_df)
 
     # TODO: It would be good to verify that there are no duplicated Element IDs (including Synapses)
-    export_neuprint_elementsets(cfg, element_tables, connectome)
+    export_neuprint_elementsets(cfg, element_tables, neuron_df.index)
     export_neuprint_elements(cfg, element_tables, element_roisets)
     export_neuprint_elements_closeto(element_tables)
 

--- a/flyem_snapshot/outputs/neuprint/segment.py
+++ b/flyem_snapshot/outputs/neuprint/segment.py
@@ -12,7 +12,7 @@ from neuclease import PrefixFilter
 from neuclease.util import timed, Timer, compute_parallel, tqdm_proxy, snakecase_to_camelcase
 
 from ...util.checksum import checksum
-from .util import append_neo4j_type_suffixes
+from .util import append_neo4j_type_suffixes, prepare_int_cols_for_export
 
 logger = logging.getLogger(__name__)
 
@@ -522,49 +522,10 @@ def _construct_export_df_for_common_roiset(neuron_df):
     assert all(':' in c for c in neuron_df.columns), \
         f"Columns aren't all ready for neo4j export: {neuron_df.columns.tolist()}"
 
-    neo4j_to_numpy = {
-        'long': np.int64,
-        'int': np.int32
-    }
-
-    # Some columns might have the wrong dtype due to the way
-    # pandas expresses missing values with NaN.
-    # To ensure that the non-missing values will be written
-    # correctly in the CSV, first convert to the correct dtype
-    # (if this batch contains no missing entries) or to 'object'
-    # dtype (if necessary) and cast the available values to the
-    # correct type.
-    for c, pandas_dtype in neuron_df.dtypes.items():
-        neo4j_type = c.split(':')[1]
-        export_type = neo4j_to_numpy.get(neo4j_type, None)
-        if not export_type or export_type == pandas_dtype:
-            continue
-
-        # For columns which should be exported as numerics,
-        # coerce incompatible values to null (but warn about them).
-        if np.issubdtype(export_type, np.number):
-            nullcount = neuron_df[c].isnull().sum()
-            neuron_df[c] = pd.to_numeric(neuron_df[c], errors='coerce')
-            if neuron_df[c].isnull().sum() > nullcount:
-                # (The current function is running in a subprocess,
-                # so we can't use the global logger variable.)
-                logging.getLogger(__name__).warning(
-                    f"Segment annotation column {c} has values which cannot be "
-                    "converted to numeric types. Setting those values to null."
-                )
-
-        if neuron_df[c].notnull().all():
-            neuron_df[c] = neuron_df[c].astype(export_type)
-        else:
-            # Convert column to dtype 'object' (instead of float)
-            # so that we can replace floats with ints while
-            # allowing for missing values.
-            neuron_df[c] = neuron_df[c].astype(object)
-            nn = neuron_df[c].notnull()
-            neuron_df.loc[nn, c] = neuron_df.loc[nn, c].astype(export_type)
+    prepare_int_cols_for_export(neuron_df)
 
     # FIXME:
-    # Technically, its *possible* (but highly unlikely)
+    # Technically, it's *possible* (but highly unlikely)
     # that our hash has collided for multiple roi sets.
     # The only way to be 100% safe is to check them all.
     # For now, I'm ignoring that problem and just assuming

--- a/flyem_snapshot/outputs/neuprint/segment.py
+++ b/flyem_snapshot/outputs/neuprint/segment.py
@@ -74,7 +74,7 @@ def export_neuprint_segments(cfg, point_df, partner_df, element_tables, ann, bod
         if (
             neuron_df[c].dtype in (bool, object)
             and len(u := neuron_df[c].dropna().unique()) <= 2  # noqa
-            and set(u) <= {True, False}                        # noqa
+            and set(u) <= {True, False}                   # noqa
         ):
             neuron_df[c] = neuron_df[c].replace([True, False], ['true', 'false'])
             neuron_df = neuron_df.rename(columns={c: f'{c}:boolean'})

--- a/flyem_snapshot/outputs/neuprint/segment.py
+++ b/flyem_snapshot/outputs/neuprint/segment.py
@@ -139,7 +139,6 @@ def _body_elm_stats(cfg, point_df, partner_df, element_tables, inbounds_bodies, 
     )
     body_element_stats = (
         pd.concat(tables, axis=1)
-        .query('body != 0')
         .fillna(0)
         .astype(np.int32)
     )
@@ -347,7 +346,6 @@ def _make_roi_infos(batch_df):
             456   -387462398472 '{"ME(R)": {"post": 45, "pre": 9, ...}, "LO(R)": {"post": 213, "pre": 12, ...}}'
         ...
     """
-    batch_df = batch_df.query('body != 0')
     batch_df = batch_df.set_index('roi')
     assert batch_df.columns[:2].tolist() == ['body_batch', 'body']
 

--- a/flyem_snapshot/outputs/neuprint/util.py
+++ b/flyem_snapshot/outputs/neuprint/util.py
@@ -4,6 +4,7 @@ import logging
 import numpy as np
 import pandas as pd
 
+
 # For certain types, we need to ensure that 'long' is used in neo4j, not int.
 # Also, in some cases (e.g. 'group'), the column in our pandas DataFrame is
 # stored with float dtype because pandas uses NaN for missing values.
@@ -23,6 +24,10 @@ NEUPRINT_TYPE_OVERRIDES = {
     # 'halfbrainBody': 'long',
     'positionType': 'string',
     'locationType': 'string',
+
+    # fish2 :Soma properties
+    'somaId': 'long',
+    'zapbenchId': 'long',
 }
 
 
@@ -140,3 +145,103 @@ def neo4j_type_suffix(series):
         f"Column {series.name} contains lists with unsupported "
         f"list entries (e.g. {valid.iloc[0][0]})"
     )
+
+
+def convert_point_cols_to_neo4j_spatial(df):
+    """
+    Convert any columns whose name contains 'location' or 'position'
+    to the string format required for neo4j spatial points in CSV files,
+
+    e.g. "{x: 123, y: 456, z: 789}"
+
+    Works in-place.
+    """
+    logger = logging.getLogger(__name__)
+
+    # Points must be converted to neo4j spatial points.
+    # FIXME: What about point-annotations which DON'T contain 'location' or 'position' in the name?
+    for col in df.columns:
+        if not re.search('position|location', col.lower()):
+            continue
+
+        # FIXME: Is there a better way to catch positionType instead of hard-coding this?
+        if col in ('positionType', 'locationType'):
+            continue
+
+        df[col] = df[col].astype(object).where(df[col].notnull(), None)
+        count = df[col].notnull().sum()
+        df[col] = df[col].map(_convert_point)
+        newcount = df[col].notnull().sum()
+        if newcount != count:
+            logger.warning(
+                f"Point annotation column {col} has {count - newcount}"
+                " values which could not be processed as points."
+            )
+
+        valid = df[col].notnull()
+        df.loc[~valid, col] = None
+        df.loc[valid, col] = [
+            f"{{x:{x}, y:{y}, z:{z}}}"
+            for (x,y,z) in df.loc[valid, col].values
+        ]
+
+
+def _convert_point(p):
+    """
+    Convert the given entity from various possible forms of point data into to a standard form.
+
+    The input may be one of the following:
+
+    - A string like '123, 456, 789'
+    - A string like '[123, 456, 789]'
+    - A string like '{x: 123, y: 456, z: 789}'
+    - A list or array of three ints or floats
+    - a neo4j spatial coordinate like this:
+        {
+            'coordinates': [24481, 36044, 67070],
+            'crs': {'name': 'cartesian-3d',
+            'properties': {'href': 'http://spatialreference.org/ref/sr-org/9157/ogcwkt/',
+            'type': 'ogcwkt'},
+            'srid': 9157,
+            'type': 'link'},
+            'type': 'Point'
+        }
+
+    The output form is just a list: [x, y, z].
+    If the input is None or cannot be interpreted as a point, then None is returned.
+    """
+    match p:
+        case None:
+            return None
+
+        case {'coordinates': coords} if len(coords) == 3:
+            return coords
+
+        case {'x': x, 'y': y, 'z': z}:
+            return [x, y, z]
+
+        case [x, y, z] if all(isinstance(v, int) for v in (x, y, z)):
+            return [x, y, z]
+
+        case [x, y, z]:
+            try:
+                return [float(x), float(y), float(z)]
+            except (ValueError, TypeError):
+                return None
+
+        case str() as s:
+            s = s.strip('[]{} ')
+
+            try:
+                pattern = (
+                    r'(?:x:\s*)?(-?\d+\.?\d*)\s*,\s*'
+                    r'(?:y:\s*)?(-?\d+\.?\d*)\s*,\s*'
+                    r'(?:z:\s*)?(-?\d+\.?\d*)\s*$'
+                )
+                if match := re.match(pattern, s):
+                    return [eval(x) for x in match.groups()]
+            except (ValueError, TypeError):
+                return None
+
+        case _:
+            return None

--- a/flyem_snapshot/outputs/neuprint/util.py
+++ b/flyem_snapshot/outputs/neuprint/util.py
@@ -147,6 +147,61 @@ def neo4j_type_suffix(series):
     )
 
 
+def prepare_int_cols_for_export(df):
+    """
+    Works in-place.
+
+    Some columns might have the wrong dtype due to the way
+    pandas expresses missing values with NaN.
+    To ensure that the non-missing values will be written
+    correctly in the CSV, we first convert to the correct dtype
+    (if the dataframe contains no missing entries) or to 'object'
+    dtype (if necessary) and cast the available values to the
+    correct type.
+
+    Args:
+        DataFrame in which the column names already have neo4j
+        type suffixes (e.g. 'foo:long').
+        Any columns without a suffix are left unchanged.
+    """
+    neo4j_to_numpy = {
+        'long': np.int64,
+        'int': np.int32
+    }
+
+    for c, pandas_dtype in df.dtypes.items():
+        if ':' not in c:
+            continue
+
+        neo4j_type = c.split(':')[1]
+        export_type = neo4j_to_numpy.get(neo4j_type, None)
+        if not export_type or export_type == pandas_dtype:
+            continue
+
+        # For columns which should be exported as numerics,
+        # coerce incompatible values to null (but warn about them).
+        if np.issubdtype(export_type, np.number):
+            nullcount = df[c].isnull().sum()
+            df[c] = pd.to_numeric(df[c], errors='coerce')
+            if df[c].isnull().sum() > nullcount:
+                # (The current function is running in a subprocess,
+                # so we can't use the global logger variable.)
+                logging.getLogger(__name__).warning(
+                    f"Segment annotation column {c} has values which cannot be "
+                    "converted to numeric types. Setting those values to null."
+                )
+
+        if df[c].notnull().all():
+            df[c] = df[c].astype(export_type)
+        else:
+            # Convert column to dtype 'object' (instead of float)
+            # so that we can replace floats with ints while
+            # allowing for missing values.
+            df[c] = df[c].astype(object)
+            nn = df[c].notnull()
+            df.loc[nn, c] = df.loc[nn, c].astype(export_type)
+
+
 def convert_point_cols_to_neo4j_spatial(df):
     """
     Convert any columns whose name contains 'location' or 'position'

--- a/flyem_snapshot/util/util.py
+++ b/flyem_snapshot/util/util.py
@@ -15,7 +15,7 @@ def replace_object_nan_with_none(df):
     for col, dtype in df.dtypes.items():
         if dtype != object:
             continue
-        df[col] = df[col].replace([np.nan], [None])
+        df[col] = df[col].where(df[col].notnull(), None)
 
 
 def restrict_synapses_to_roi(roiset, roi, point_df, partner_df):


### PR DESCRIPTION
"Elements" are points such as mito or ColumnPins that Segments can "Contain".

Previously, we only supported loading them from disk.  With this PR, we now support loading them from a DVID `annotation` instance, including any properties they have.

Related: The config now supports the option to permit elements that happen to fall on body `0`.  Previously, they were always filtered out.

I've already used this PR to add new `Soma` elements to the `fish2` dataset, pulled directly from DVID.

cc @robsv 